### PR TITLE
support for jetbrains editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ Thumbs.db
 .envrc
 .env
 .ruby-gemset
+.idea/
 .vscode
 yarn-error.log


### PR DESCRIPTION
Add `.idea/` to `.gitignore` to support for Jetbrains/IntelliJ editors.